### PR TITLE
[13.0][IMP] pricelist_items_auto_update_date: enable hide auto update by default

### DIFF
--- a/pricelist_items_auto_update_date/__manifest__.py
+++ b/pricelist_items_auto_update_date/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.2",
+    "version": "13.0.2.0.0",
     'category': "Product",
     "website": "https://github.com/solvosci/slv-product",
     "depends": ["product"],

--- a/pricelist_items_auto_update_date/models/pricelist_items.py
+++ b/pricelist_items_auto_update_date/models/pricelist_items.py
@@ -11,6 +11,8 @@ class ProductPricelistItem(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        if self.env.context.get("skip_auto_update_date", True):
+            return super().create(vals_list)
 
         # Refactor code ...
         # Adding elements from the form: In the case that more than one


### PR DESCRIPTION
With this improvement, now this addon doesn't do anything if it's not passed certain context key.

Then, any addon that want to strictly use the functionality when creating a pricelist item must indicate by context it.