### PR TITLE
[16.0][FIX] product_secondary_unit_factor_digits: missing __init__.py file

### DIFF
--- a/product_secondary_unit_factor_digits/__manifest__.py
+++ b/product_secondary_unit_factor_digits/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "Product",
     "website": "https://github.com/solvosci/slv-product",
     "depends": ["product_secondary_unit"],


### PR DESCRIPTION
Some automatic processes (like dockerdoo `addons_path` calculation) needs this file available for at lest a module within a repository. Otherwise, complete report folder will be ignored. This fixes it.